### PR TITLE
update container image tag

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,8 +16,9 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           # list of Docker images to use as base name for tags
+          # use naming convention: training-[coursenameinoneword]-[imagetype]
           images: |
-            geertvangeest/ngs-introduction-vscode
+            sibswiss/training-introsequencing-vscode
           # generate Docker tags based on the following events/attributes
           tags: |
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
I've set the image name to: 

```
sibswiss/training-introsequencing-vscode
```

so, `sibswiss/training-[course title in one word]-[container type]`
we can also use the course abbreviation (i.e. ISEDA) instead of the 'course title in one word', which is a bit more standardized. However, it would become a bit less easy to recognize by humans. 